### PR TITLE
Feat: Add Mongoose models for User, Strategy, Order

### DIFF
--- a/backend/src/models/Order.js
+++ b/backend/src/models/Order.js
@@ -1,0 +1,21 @@
+'use strict';
+
+const mongoose = require('mongoose');
+
+const orderSchema = new mongoose.Schema({
+  userId: { type: mongoose.Schema.Types.ObjectId, ref: 'User', default: null },
+  strategyId: { type: String, default: null },
+  activeId: { type: Number, required: true },
+  direction: { type: String, enum: ['call', 'put'], required: true },
+  amount: { type: Number, required: true },
+  duration: { type: Number, required: true },
+  orderType: { type: String, enum: ['binary', 'turbo', 'digital'], default: 'digital' },
+  status: { type: String, enum: ['open', 'closed', 'cancelled'], default: 'open' },
+  openQuote: { type: Number, default: null },
+  closeQuote: { type: Number, default: null },
+  pnl: { type: Number, default: null },
+  openedAt: { type: Date, default: Date.now },
+  closedAt: { type: Date, default: null }
+}, { timestamps: true });
+
+module.exports = mongoose.model('Order', orderSchema);

--- a/backend/src/models/Strategy.js
+++ b/backend/src/models/Strategy.js
@@ -1,0 +1,24 @@
+'use strict';
+
+const mongoose = require('mongoose');
+
+const strategySchema = new mongoose.Schema({
+  userId: { type: mongoose.Schema.Types.ObjectId, ref: 'User', default: null },
+  type: { type: String, required: true },
+  name: { type: String, required: true },
+  description: { type: String, default: '' },
+  version: { type: String, default: '1.0.0' },
+  params: { type: mongoose.Schema.Types.Mixed, default: {} },
+  status: { type: String, enum: ['stopped', 'running', 'paused', 'error'], default: 'stopped' },
+  activeId: { type: Number, default: null },
+  stats: {
+    totalOrders: { type: Number, default: 0 },
+    wins: { type: Number, default: 0 },
+    losses: { type: Number, default: 0 },
+    totalPnl: { type: Number, default: 0 },
+    startedAt: { type: Date, default: null },
+    lastSignalAt: { type: Date, default: null }
+  }
+}, { timestamps: true });
+
+module.exports = mongoose.model('Strategy', strategySchema);

--- a/backend/src/models/User.js
+++ b/backend/src/models/User.js
@@ -1,0 +1,24 @@
+'use strict';
+
+const mongoose = require('mongoose');
+
+const userSchema = new mongoose.Schema({
+  email: { type: String, required: true, unique: true, lowercase: true, trim: true },
+  password: { type: String, required: true },
+  role: { type: String, enum: ['user', 'admin'], default: 'user' },
+  iqEmail: { type: String, default: null },
+  iqPassword: { type: String, default: null },
+  refreshToken: { type: String, default: null },
+  isActive: { type: Boolean, default: true },
+  lastLoginAt: { type: Date, default: null }
+}, { timestamps: true });
+
+userSchema.methods.toJSON = function () {
+  const obj = this.toObject();
+  delete obj.password;
+  delete obj.iqPassword;
+  delete obj.refreshToken;
+  return obj;
+};
+
+module.exports = mongoose.model('User', userSchema);


### PR DESCRIPTION
- User schema: email, password, role, iqEmail, iqPassword, timestamps
- Strategy schema: type, params, asset, timeframe, activeId, status
- Order schema: positionId, activeId, direction, amount, result

Note: Controllers still use in-memory Map storage (not wired yet).

Closes #17